### PR TITLE
removing response format

### DIFF
--- a/Quick_start_notebook.ipynb
+++ b/Quick_start_notebook.ipynb
@@ -799,7 +799,6 @@
     "            \"body\": {\n",
     "                \"model\": \"klusterai/Meta-Llama-3.1-405B-Instruct-Turbo\",\n",
     "                \"temperature\": 0.5,\n",
-    "                \"response_format\": {\"type\": \"json_object\"},\n",
     "                \"messages\": [\n",
     "                    {\"role\": \"system\", \"content\": system_prompt},\n",
     "                    {\"role\": \"user\", \"content\": content}\n",


### PR DESCRIPTION
we currently don't support the response_format parameter in requests, so removing it from example.