### PR TITLE
Fix Reliability Check Link

### DIFF
--- a/examples/reliability-check.ipynb
+++ b/examples/reliability-check.ipynb
@@ -17,7 +17,7 @@
     "id": "b17a77d9"
    },
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/tutorials/kluster-api/reliability-check.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/examples/reliability-check.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
Fix Reliability Check Link
This pull request includes a minor change to the `examples/reliability-check.ipynb` file. The change updates the URL in the "Open in Colab" badge to point to the correct file path within the repository.