### PR TITLE
Revise Hallucinations Workbook

### DIFF
--- a/examples/combat-hallucinations.ipynb
+++ b/examples/combat-hallucinations.ipynb
@@ -15,12 +15,12 @@
       "id": "581c9428",
       "metadata": {},
       "source": [
-        "Large language models occasionally invent facts (“hallucinations”). **[kluster Verify](https://docs.kluster.ai/get-started/verify/reliability/overview/)** is a drop‑in fact‑checker that scores any LLM response for reliability—either with one click inside the [kluster Playground](https://platform.kluster.ai/playground) or via a simple API call.\n",
+        "Large language models occasionally invent facts (“hallucinations”). **[kluster Verify](https://docs.kluster.ai/get-started/verify/reliability/overview/)** is a drop‑in fact‑checker that scores any LLM response for reliability, either with one click inside the [kluster Playground](https://platform.kluster.ai/playground) or via a simple API call.\n",
         "\n",
         "This notebook shows you how to:\n",
         "1. Call the `POST /v1/verify/reliability` endpoint to fact‑check model output programmatically.\n",
         "2. Interpret the JSON response returned by kluster Verify.\n",
-        "3. Apply best‑practice guard‑rails in your own applications.\n",
+        "3. Apply best‑practice guardrails in your applications.\n",
         "\n",
         "> **Note** – We use *mistral‑small‑2506* as the demo model to generate the example prompt responses. Performance varies by model and prompt, so feel free to experiment."
       ]
@@ -30,20 +30,20 @@
       "id": "08080c97",
       "metadata": {},
       "source": [
-        "## How kluster Verify works under the hood\n",
+        "## How kluster Verify Works Under the Hood\n",
         "\n",
-        "1. **Inputs**: You send at least two fields:\n",
+        "1. **Inputs**:\n",
         "   * `prompt`: The original user request.\n",
         "   * `output`: The LLM’s response to be checked.\n",
         "   * *(Optional)* `context`: A set of ground‑truth docs (URLs, text, PDFs, etc.) that Verify **only** reads in this sandbox.\n",
         "2. **Retrieval & evidence gathering**: If `context` is omitted, Verify performs real‑time web search and retrieval, pulling the top public sources most likely to contain evidence.\n",
-        "3. **Cross‑examination**: Verify compares factual claims in `output` against the gathered evidence.\n",
-        "4. **Results**: verify returns:\n",
-        "   * `is_hallucination` – Boolean verdict.\n",
-        "   * `explanation` – Natural‑language rationale.\n",
-        "   * `search_results` – List of URLs & snippets (if `return_search_results=true`).\n",
+        "3. **Cross‑examination**: Verify compares factual claims in the `output` against the gathered evidence.\n",
+        "4. **Verify response**:\n",
+        "   * `is_hallucination`: Boolean verdict\n",
+        "   * `explanation`: Natural‑language rationale\n",
+        "   * `search_results`: List of URLs and snippets (if `return_search_results=true`)\n",
         "\n",
-        "This pipeline adds **~1–2 sec** latency for short answers and gives you structured evidence for audit and debugging."
+        "This pipeline adds **~1–2 seconds** of latency for short answers and provides structured evidence for audit and debugging."
       ]
     },
     {
@@ -53,8 +53,8 @@
       "source": [
         "## Prerequisites\n",
         "\n",
-        "- A **kluster.ai account**: sign up at <https://platform.kluster.ai/signup>\n",
-        "- A **kluster.ai api key**: create one in **api keys** (<https://platform.kluster.ai/apikeys>)"
+        "- **kluster.ai account**: Sign up at <https://platform.kluster.ai/signup>.\n",
+        "- **kluster.ai api key**: Create one at <https://platform.kluster.ai/apikeys>."
       ]
     },
     {
@@ -70,7 +70,7 @@
       "id": "546df0e5",
       "metadata": {},
       "source": [
-        "Install required libraries. The kluster API is OpenAI‑compatible, so you can reuse the `openai` Python client. You'll also need `requests`."
+        "Install the required libraries. Since the kluster API is OpenAI‑compatible, you can reuse the `openai` Python client, but you'll also need `requests`."
       ]
     },
     {
@@ -119,7 +119,7 @@
       "source": [
         "## Example 1 – Artemis IV Lunar Base (future event)\n",
         "\n",
-        "The *Artemis IV* mission is real but **has not launched yet** (scheduled no earlier than 2028). Asking for an “official NASA mission log” dated **14 May 2025** nudges the model to invent a detailed account, because no such log exists. This makes it an excellent stress‑test for hallucination detection."
+        "The *Artemis IV* mission is real but **has not launched yet** (scheduled no earlier than 2028). Asking for an “official NASA mission log” dated **14 May 2025** nudges the model to invent a detailed account, because no such log exists. This makes it an excellent stress test for hallucination detection."
       ]
     },
     {
@@ -143,7 +143,7 @@
       "source": [
         "### Verify via API\n",
         "\n",
-        "In the next cell we pass the prompt and model output to the Kluster Verify API, along with a flag requesting the search results it used. Kluster Verify then returns a verdict, a short explanation, and the supporting sources."
+        "In the next cell we pass the prompt and model output to the kluster Verify API, along with a flag requesting the search results it used. kluster Verify then returns a verdict, a short explanation, and the supporting sources."
       ]
     },
     {
@@ -182,7 +182,7 @@
       "source": [
         "## Example 2 – The Fictional *Tokyo Green Pact*\n",
         "\n",
-        "There is no treaty called the **Tokyo Green Pact** signed by the G20. By requesting its binding provisions and penalties, we again corner the model into making things up, which kluster Verify should flag."
+        "There is no treaty called the **Tokyo Green Pact** that has been signed by the G20. By requesting its binding provisions and penalties, we again corner the model into making things up, which kluster Verify should flag."
       ]
     },
     {
@@ -234,7 +234,7 @@
       "metadata": {},
       "source": [
         "## Best Practices\n",
-        "1. **Auto‑verify short answers**: The [kluster Playground](https://platform.kluster.ai/playground) has an auto-verify feature that you can enable with one click\n",
+        "1. **Auto‑verify short answers**: The [kluster Playground](https://platform.kluster.ai/playground) has an auto-verify feature that you can enable with one click.\n",
         "2. **Block, regenerate, or escalate**: Whenever `is_hallucination == true`, take corrective action.\n",
         "3. **Constrain with `context`**: When context is provided, the service only validates answers against the specified context.\n",
         "4. **Log evidence**: Keep `search_results` so reviewers can audit decisions.\n",
@@ -249,7 +249,7 @@
       "source": [
         "## Summary\n",
         "\n",
-        "Whether you prefer the Playground’s one-click Verify button or the /v1/verify/reliability API, you now have a turnkey way to validate any LLM response. Because kluster Verify pairs its verdict with an evidence-backed score and live source links, you can log proof, set automated “regen” or escalation thresholds, and keep hallucinations from ever reaching production users."
+        "Whether you prefer the Playground’s one-click Verify button or the /v1/verify/reliability API, you now have a turnkey way to validate any LLM response. Since kluster Verify pairs its verdict with an evidence-backed score and live source links, you can log proof, set automated “regen” or escalation thresholds, and keep hallucinations from ever reaching production users."
       ]
     }
   ],


### PR DESCRIPTION
This pull request focuses on refining the language and formatting in the `examples/combat-hallucinations.ipynb` notebook to improve clarity, consistency, and professionalism. The changes primarily involve rephrasing sentences, correcting grammar, and standardizing capitalization.

### Language and grammar improvements:

- Rephrased sentences for smoother readability and corrected minor grammatical issues, such as "guard‑rails" to "guardrails" and "stress‑test" to "stress test." [[1]](diffhunk://#diff-ec2ea56e90f5c2a1c034bd446b98070b95746fbf3af2c9d7052f3be6fa5ad5e0L18-R23) [[2]](diffhunk://#diff-ec2ea56e90f5c2a1c034bd446b98070b95746fbf3af2c9d7052f3be6fa5ad5e0L122-R122)
- Adjusted phrasing for clarity, e.g., "Install required libraries" changed to "Install the required libraries" for better flow.

### Consistency in capitalization and formatting:

- Standardized capitalization in headings, e.g., "How kluster Verify works under the hood" changed to "How kluster Verify Works Under the Hood."
- Ensured consistent formatting of API descriptions and best practices, such as adding periods at the end of list items and refining bullet points. [[1]](diffhunk://#diff-ec2ea56e90f5c2a1c034bd446b98070b95746fbf3af2c9d7052f3be6fa5ad5e0L237-R237) [[2]](diffhunk://#diff-ec2ea56e90f5c2a1c034bd446b98070b95746fbf3af2c9d7052f3be6fa5ad5e0L56-R57)

### Enhanced clarity in examples and summaries:

- Improved example descriptions for better understanding, e.g., clarified the fictional nature of the "Tokyo Green Pact" example.
- Refined the summary section for conciseness and clarity, e.g., "Because kluster Verify pairs its verdict..." changed to "Since kluster Verify pairs its verdict..."