### PR TITLE
revise hallucinations tutorial

### DIFF
--- a/examples/combat-hallucinations.ipynb
+++ b/examples/combat-hallucinations.ipynb
@@ -5,7 +5,7 @@
       "id": "76f1454d",
       "metadata": {},
       "source": [
-        "# Combat Hallucinations with **kluster Verify**\n",
+        "# Combat Hallucinations with **Verify Reliability**\n",
         "\n",
         "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kluster-ai/klusterai-cookbook/blob/main/examples/combat-hallucinations.ipynb)"
       ]
@@ -15,11 +15,11 @@
       "id": "581c9428",
       "metadata": {},
       "source": [
-        "Large language models occasionally invent facts (“hallucinations”). **[kluster Verify](https://docs.kluster.ai/get-started/verify/reliability/overview/)** is a drop‑in fact‑checker that scores any LLM response for reliability, either with one click inside the [kluster Playground](https://platform.kluster.ai/playground) or via a simple API call.\n",
+        "Large language models occasionally invent facts (“hallucinations”). **[Verify Reliability](https://docs.kluster.ai/get-started/verify/reliability/overview/)** is a drop‑in fact‑checker that scores any LLM response for reliability, either with one click inside the [kluster Playground](https://platform.kluster.ai/playground) or via a simple API call.\n",
         "\n",
         "This notebook shows you how to:\n",
         "1. Call the `POST /v1/verify/reliability` endpoint to fact‑check model output programmatically.\n",
-        "2. Interpret the JSON response returned by kluster Verify.\n",
+        "2. Interpret the JSON response returned by Verify Reliability.\n",
         "3. Apply best‑practice guardrails in your applications.\n",
         "\n",
         "> **Note** – We use *mistral‑small‑2506* as the demo model to generate the example prompt responses. Performance varies by model and prompt, so feel free to experiment."
@@ -30,7 +30,7 @@
       "id": "08080c97",
       "metadata": {},
       "source": [
-        "## How kluster Verify Works Under the Hood\n",
+        "## How Verify Reliability Works Under the Hood\n",
         "\n",
         "1. **Inputs**:\n",
         "   * `prompt`: The original user request.\n",
@@ -143,7 +143,7 @@
       "source": [
         "### Verify via API\n",
         "\n",
-        "In the next cell we pass the prompt and model output to the kluster Verify API, along with a flag requesting the search results it used. kluster Verify then returns a verdict, a short explanation, and the supporting sources."
+        "In the next cell we pass the prompt and model output to the Verify Reliability API, along with a flag requesting the search results it used. Verify Reliability then returns a verdict, a short explanation, and the supporting sources."
       ]
     },
     {
@@ -182,7 +182,7 @@
       "source": [
         "## Example 2 – The Fictional *Tokyo Green Pact*\n",
         "\n",
-        "There is no treaty called the **Tokyo Green Pact** that has been signed by the G20. By requesting its binding provisions and penalties, we again corner the model into making things up, which kluster Verify should flag."
+        "There is no treaty called the **Tokyo Green Pact** that has been signed by the G20. By requesting its binding provisions and penalties, we again corner the model into making things up, which Verify Reliability should flag."
       ]
     },
     {
@@ -249,7 +249,7 @@
       "source": [
         "## Summary\n",
         "\n",
-        "Whether you prefer the Playground’s one-click Verify button or the /v1/verify/reliability API, you now have a turnkey way to validate any LLM response. Since kluster Verify pairs its verdict with an evidence-backed score and live source links, you can log proof, set automated “regen” or escalation thresholds, and keep hallucinations from ever reaching production users."
+        "Whether you prefer the Playground’s one-click Verify button or the /v1/verify/reliability API, you now have a turnkey way to validate any LLM response. Since Verify Reliability pairs its verdict with an evidence-backed score and live source links, you can log proof, set automated “regen” or escalation thresholds, and keep hallucinations from ever reaching production users."
       ]
     }
   ],


### PR DESCRIPTION
This pull request updates the terminology in the `examples/combat-hallucinations.ipynb` file, replacing references to "kluster Verify" with "Verify Reliability" to align with updated naming conventions.

### Terminology Updates:

* Updated the title of the notebook from "Combat Hallucinations with **kluster Verify**" to "Combat Hallucinations with **Verify Reliability**."
* Replaced mentions of "kluster Verify" with "Verify Reliability" in the description of the fact-checking tool and its API usage. [[1]](diffhunk://#diff-ec2ea56e90f5c2a1c034bd446b98070b95746fbf3af2c9d7052f3be6fa5ad5e0L18-R22) [[2]](diffhunk://#diff-ec2ea56e90f5c2a1c034bd446b98070b95746fbf3af2c9d7052f3be6fa5ad5e0L146-R146)
* Changed section headers such as "How kluster Verify Works Under the Hood" to "How Verify Reliability Works Under the Hood."
* Updated example descriptions to reference "Verify Reliability" for flagging hallucinations instead of "kluster Verify."
* Revised the summary to reflect the new name, emphasizing the functionality of "Verify Reliability" for validating LLM responses.